### PR TITLE
fix: Run on ubuntu >=v23 without error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ const run = async (): Promise<void> => {
   if (input.createMd) {
     writeFileSync(`./${mdFile}`, jobSummary);
   }
-  
+
   const configFileName = '_config.js';
   // https://gist.github.com/danishcake/d045c867594d6be175cb394995c90e2c#file-readme-md
   const config = `// A marked renderer for mermaid diagrams
@@ -97,7 +97,7 @@ const renderer = {
 module.exports = {
     marked_extensions: [{ renderer }],
     script: [
-        { url: 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js' },  
+        { url: 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js' },
         // Alternative to above: if you have no Internet access, you can also embed a local copy
         // { content: require('fs').readFileSync('./node_modules/mermaid/dist/mermaid.js', 'utf-8') }
         // For some reason, mermaid initialize doesn't render diagrams as it should. It's like it's missing
@@ -107,9 +107,9 @@ module.exports = {
 };`;
   execSync(`npm i -g md-to-pdf`);
   writeFileSync(configFileName, config);
-  execSync(`md-to-pdf --config-file ./${configFileName} ./${mdFile}`);
+  execSync(`md-to-pdf --launch-options '{ "args": ["--no-sandbox"] }' --config-file ./${configFileName} ./${mdFile}`);
   info('PDF generated successfully');
-  execSync(`md-to-pdf --config-file ./${configFileName} ./${mdFile} --as-html`);
+  execSync(`md-to-pdf --launch-options '{ "args": ["--no-sandbox"] }' --config-file ./${configFileName} ./${mdFile} --as-html`);
   info('HTML generated successfully');
   unlinkSync(configFileName);
 


### PR DESCRIPTION
* Updated args to md-to-pdf to include a --no-sandbox argument to puppeteer. See [simonhaenisch/md-to-pdf Issue #20](https://github.com/simonhaenisch/md-to-pdf/issues/20) for details on argument.

Fixes: [Issue #46](https://github.com/austenstone/job-summary/issues/46)